### PR TITLE
Fix/translations

### DIFF
--- a/src/Components/SelectionBox/SelectionBox.jsx
+++ b/src/Components/SelectionBox/SelectionBox.jsx
@@ -52,10 +52,10 @@ const SelectionBox = ({
       </div>
       <div className="select-box-description">
         <ul className="select-box-description-ul">
-          {pro.map((text, i) => (
+          {(typeof pro === "string" ? [pro] : pro).map((text, i) => (
             <Item text={text} Icon={CheckIcon} key={i} />
           ))}
-          {contra.map((text, i) => (
+          {(typeof contra === "string" ? [contra] : contra).map((text, i) => (
             <Item text={text} Icon={CloseIcon} key={i} />
           ))}
         </ul>

--- a/src/Forms/VocabForm/VocabForm.jsx
+++ b/src/Forms/VocabForm/VocabForm.jsx
@@ -433,13 +433,17 @@ const VocabForm = ({
         </div>
       </form>
       <Modal
-        title={"Add Package"}
+        title={t("screens.allPackages.addPackage")}
         open={showAddPackage}
         onClose={closePackageModal}
       >
         <PackageForm onSubmitCallback={packageAdded} />
       </Modal>
-      <Modal title={"Add Group"} open={showAddGroup} onClose={closeGroupModal}>
+      <Modal
+        title={t("screens.allGroups.addGroup")}
+        open={showAddGroup}
+        onClose={closeGroupModal}
+      >
         <GroupForm
           fixedPackage
           selectedPackage={selectedPackage}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  |
| :---: | :---: |
| :white_check_mark: Ready  | Bug |

## Description

- fixes an error if a user sets the language to german and then opens the selection screen. This is related to localazy and its exporting behavier of arrays with only one element.
- adds translations to the headlines in the add package/group modals which are accessed from within the add vocab page.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):
<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
