### PR TITLE
fix linebreaks on vocab card and vocab table

### DIFF
--- a/src/Components/VocabCard/VocabCard.jsx
+++ b/src/Components/VocabCard/VocabCard.jsx
@@ -18,7 +18,7 @@ const RenderForeignWord = ({ currVocab, isTranslation }) => {
   return (
     <div className="foreign-word-wrapper">
       {isTranslation ? (
-        <p className="description">{currVocab.description}</p>
+        <p className="description text-wrap">{currVocab.description}</p>
       ) : null}
       <h1 className={`${isTranslation ? "translations" : ""}`}>
         {currVocab.name}
@@ -41,7 +41,9 @@ const RenderTranslatedWord = ({ currVocab, isTranslation }) => {
 
   return (
     <div className="translated-word-wrapper">
-      {isTranslation ? <p className="my-20">{currVocab.description}</p> : null}
+      {isTranslation ? (
+        <p className="my-20 text-wrap">{currVocab.description}</p>
+      ) : null}
       <div className={`my-20 ${isTranslation ? "translations" : ""}`}>
         {currVocab.Translations.map((el) => el.name).join(", ")}
       </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -28,6 +28,14 @@
   &-bold {
     font-weight: bold !important;
   }
+
+  &-wrap {
+    white-space: pre-wrap;
+  }
+
+  &-left {
+    text-align: left;
+  }
 }
 
 .w {

--- a/src/screens/Library/AllVocabs/AllVocabs.jsx
+++ b/src/screens/Library/AllVocabs/AllVocabs.jsx
@@ -89,7 +89,7 @@ const AllVocabs = () => {
         accessor: "name",
         Cell: ({ row }) => (
           <Button
-            className="text-normal"
+            className="text-normal text-left"
             variant="link"
             onClick={() => editVocab(row.original)}
           >
@@ -101,9 +101,7 @@ const AllVocabs = () => {
         Header: t("screens.allVocabs.description"),
         accessor: "description",
         Cell: ({ row }) => (
-          <div style={{ textAlign: "left" }}>
-            <p>{row.original.description}</p>
-          </div>
+          <p className="text-left text-wrap">{row.original.description}</p>
         ),
       },
       {
@@ -114,7 +112,7 @@ const AllVocabs = () => {
         Header: t("screens.allGroups.active"),
         accessor: "active",
         Cell: ({ row }) => (
-          <div style={{ textAlign: "left" }}>
+          <div>
             {row.original.active ? (
               <CheckCircleIcon className="text-success" />
             ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  |
| :---: | :---: |
| :white_check_mark: Ready  | Bug |

## Description

Show line wraps in description on description column and on vocab card.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):
<!--- Bonus points for GIFS --->

![image](https://user-images.githubusercontent.com/60048565/150802920-69b94fd7-4c12-4f11-9cd2-af8a70674ad8.png)
![image](https://user-images.githubusercontent.com/60048565/150803672-003cf076-c7e6-4409-94ea-4fe10bbcb558.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
