### PR TITLE
Added basic touchbar implementation for query screen

### DIFF
--- a/src/Components/VocabCard/VocabCard.jsx
+++ b/src/Components/VocabCard/VocabCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
@@ -6,6 +6,11 @@ import Button from "../Button/Button.jsx";
 import Flag from "../Flag/Flag.jsx";
 
 import useLanguage from "../../hooks/useLanguage.js";
+import {
+  touchbarSelect,
+  available as touchBarAvailable,
+  touchbarReset,
+} from "../../modules/touchbar.js";
 
 import "./VocabCard.scss";
 
@@ -74,6 +79,37 @@ const VocabCard = ({
       return !prev;
     });
   }, [onFlip]);
+
+  useEffect(() => {
+    if (touchBarAvailable) {
+      touchbarSelect({
+        options: [
+          {
+            id: 0,
+            label: t("global.wrong"),
+            accessibilityLabel: "Select",
+            backgroundColor: "#ff586e",
+          },
+          {
+            id: 1,
+            label: t("global.correct"),
+            accessibilityLabel: "Select",
+            backgroundColor: "#0acf97",
+          },
+        ],
+      }).then(([err, x]) => {
+        // return if error -> not supported
+        if (err) return;
+
+        if (x.id === 0) onWrong();
+        else if (x.id === 1) onCorrect();
+      });
+
+      return () => touchbarReset();
+    }
+
+    return () => {};
+  }, [onCorrect, onWrong, t]);
 
   return (
     <div className="vocab-card">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  |
| :---: | :---: |
| :x: Hold | Feature |

## Description

This PR adds the possibility to use the Touch Bar of a MacBook for certain operations. Currently the following are implemented. 
**If you have some other ideas where the Touch Bar could be useful. Feel free to comment below.** 

- [x] Query-screen
- [ ] Dialogs

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):
<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
