### PR TITLE
Fix: nav external links

### DIFF
--- a/src/Components/Nav/MobileTopNav.jsx
+++ b/src/Components/Nav/MobileTopNav.jsx
@@ -159,7 +159,7 @@ const MobileTopNav = () => {
         <div className="mtn-external-link-wrapper">
           {isLegalNoticeValid && (
             <div className="mtn-external-link">
-              <VerifiedUserIcon />
+              <VerifiedUserIcon className="mtn-external-link-icon" />
               <a target="_blank" href={legalNoticeUrl} rel="noreferrer">
                 {t("global.legalNotice")}
               </a>
@@ -168,7 +168,7 @@ const MobileTopNav = () => {
 
           {isTermsAndConditionsValid && (
             <div className="mtn-external-link">
-              <PolicyIcon />
+              <PolicyIcon className="mtn-external-link-icon" />
               <a target="_blank" href={termsAndConditionsUrl} rel="noreferrer">
                 {t("global.termsAndConditions")}
               </a>
@@ -177,7 +177,7 @@ const MobileTopNav = () => {
 
           {isPrivacyPolicyValid && (
             <div className="mtn-external-link">
-              <SecurityIcon />
+              <SecurityIcon className="mtn-external-link-icon" />
               <a target="_blank" href={privacyPolicyUrl} rel="noreferrer">
                 {t("global.privacyPolicy")}
               </a>

--- a/src/Components/Nav/MobileTopNav.scss
+++ b/src/Components/Nav/MobileTopNav.scss
@@ -95,6 +95,7 @@
     width: 100%;
     height: 90%;
     padding-top: 64px;
+    overflow-y: scroll;
   }
 
   .mtn-external-link-wrapper {

--- a/src/Components/Nav/MobileTopNav.scss
+++ b/src/Components/Nav/MobileTopNav.scss
@@ -98,19 +98,26 @@
   }
 
   .mtn-external-link-wrapper {
-    margin: 8px auto;
-    font-size: 16px;
-    color: $color-main-text-inverse;
-    opacity: 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    margin: 8px 0;
+    color: $color-main-text;
 
     .mtn-external-link {
       display: flex;
       align-items: center;
       margin: 4px 0;
 
+      .mtn-external-link-icon {
+        font-size: 16px;
+      }
+
       a {
         margin-left: 4px;
-        color: $color-main-text-inverse;
+        font-size: 12px;
+        color: $color-main-text;
         text-decoration: none;
       }
     }

--- a/src/Components/Nav/MobileTopNav.scss
+++ b/src/Components/Nav/MobileTopNav.scss
@@ -94,14 +94,14 @@
     flex-direction: column;
     width: 100%;
     height: 90%;
-    padding-top: 64px;
+    margin-top: 64px;
     overflow-y: scroll;
   }
 
   .mtn-external-link-wrapper {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: center;
     width: 100%;
     margin: 8px 0;
     color: $color-main-text;
@@ -109,7 +109,7 @@
     .mtn-external-link {
       display: flex;
       align-items: center;
-      margin: 4px 0;
+      margin: 4px 10px;
 
       .mtn-external-link-icon {
         font-size: 16px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  |
| :---: | :---: |
| :x: Hold | Hotfix |

## Description

This PR fixes the appearance external links (Legal Notice, Terms and Conditions, Privacy Policy) in the mobile top nav, because I forgot to remove the opacity property in the CSS file. In addition to this, I have rearranged the links.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need this fix for legal purposes. 

## Screenshots / GIFs (if appropriate):
<!--- Bonus points for GIFS --->
<img src="https://user-images.githubusercontent.com/54618409/174485249-36b48438-cab9-4a75-84c2-b59f5bf0c334.jpg" width="300">
<img src="https://user-images.githubusercontent.com/54618409/174485251-1bf98fdd-a3a0-46f4-9b55-24f2eca48092.jpg" width="300">


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
